### PR TITLE
Fix highlighting for unnamed functions

### DIFF
--- a/zs/src/zs.YAML-tmLanguage
+++ b/zs/src/zs.YAML-tmLanguage
@@ -230,8 +230,8 @@ repository:
     name: meta.definition.function.zs
     begin: |
       (?x)
-      (fun)\s+
-      ({{identifier}})
+      (fun)
+      (\s+{{identifier}})?
       # (?=\s*[\(])
     beginCaptures:
       "1": { name: keyword.control.function.zs }


### PR DESCRIPTION
This PR fixed highlighting for functions of the form:
```zs
fun() {}
```